### PR TITLE
Jenkins対応

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function (file) {
   process.env.JSHINT_CHECKSTYLE_FILE = process.env.HTMLHINT_CHECKSTYLE_FILE || 'htmlhint-checkstyle.xml';
   return checkstyle.reporter(file.htmlhint.messages.map(function (errMsg) {
     return {
-      file: path.relative(file.cwd, errMsg.file),
+      file: errMsg.file,
       error: {
         severity: errMsg.error.type,
         character: errMsg.error.col,


### PR DESCRIPTION
解析対象ファイルのパスが相対パスの場合、Jenkinsの詳細結果表示の際に参照エラーとなるため、絶対表示に変更する。